### PR TITLE
Add `re` for inverting `Optic`s

### DIFF
--- a/src/Quartz.elm
+++ b/src/Quartz.elm
@@ -1,6 +1,6 @@
 module Quartz exposing
     ( Optic, SimpleOptic
-    , Iso, SimpleIso, iso
+    , Iso, SimpleIso, iso, from
     , Prism, SimplePrism, prism
     , Lens, SimpleLens, lens
     , Traversal, SimpleTraversal, traversal
@@ -23,7 +23,7 @@ module Quartz exposing
 
 # Isos
 
-@docs Iso, SimpleIso, iso
+@docs Iso, SimpleIso, iso, from
 
 
 # Prisms
@@ -153,6 +153,18 @@ functions for both directions.
 iso : (s -> a) -> (b -> t) -> Iso p l s t a b
 iso =
     Quartz.Type.Iso.iso
+
+
+{-| Use this function to flip an `Iso` around.
+
+    stringIso : SimpleIso () () Name String
+    stringIso =
+        from nameIso
+
+-}
+from : Iso () () s t a b -> Iso () () b a t s
+from =
+    Quartz.Type.Iso.from
 
 
 {-| This is an `Optic` that can be used to represent a constructor. Note that

--- a/src/Quartz.elm
+++ b/src/Quartz.elm
@@ -1,6 +1,6 @@
 module Quartz exposing
-    ( Optic, SimpleOptic
-    , Iso, SimpleIso, iso, from
+    ( Optic, SimpleOptic, re
+    , Iso, SimpleIso, iso
     , Prism, SimplePrism, prism
     , Lens, SimpleLens, lens
     , Traversal, SimpleTraversal, traversal
@@ -18,12 +18,12 @@ module Quartz exposing
 
 # Optics
 
-@docs Optic, SimpleOptic
+@docs Optic, SimpleOptic, re
 
 
 # Isos
 
-@docs Iso, SimpleIso, iso, from
+@docs Iso, SimpleIso, iso
 
 
 # Prisms
@@ -126,6 +126,22 @@ type alias SimpleOptic p l s a =
     Quartz.Type.Optic.SimpleOptic p l s a
 
 
+{-| Use this function to flip an `Optic` around.
+
+    stringToList : SimpleIso String (List Char)
+    stringToList =
+        iso String.toList String.fromList
+
+    listToString : SimpleIso (List Char) String
+    listToString =
+        re stringToList
+
+-}
+re : Optic () () s t a b -> Optic p l b a t s
+re =
+    Quartz.Type.Optic.re
+
+
 {-| This is an `Optic` that represents an isomorphism. Two types are isomorphic
 if you can convert between them without losing any information.
 -}
@@ -153,18 +169,6 @@ functions for both directions.
 iso : (s -> a) -> (b -> t) -> Iso p l s t a b
 iso =
     Quartz.Type.Iso.iso
-
-
-{-| Use this function to flip an `Iso` around.
-
-    stringIso : SimpleIso () () Name String
-    stringIso =
-        from nameIso
-
--}
-from : Iso () () s t a b -> Iso () () b a t s
-from =
-    Quartz.Type.Iso.from
 
 
 {-| This is an `Optic` that can be used to represent a constructor. Note that

--- a/src/Quartz/Type/Iso.elm
+++ b/src/Quartz/Type/Iso.elm
@@ -1,4 +1,4 @@
-module Quartz.Type.Iso exposing (Iso, SimpleIso, from, iso)
+module Quartz.Type.Iso exposing (Iso, SimpleIso, iso)
 
 import Quartz.Type.Optic as Optic
 
@@ -17,13 +17,4 @@ iso s2a b2t =
     , review = always b2t
     , toListOf = s2a >> List.singleton
     , view = always s2a
-    }
-
-
-from : Iso () () s t a b -> Iso () () b a t s
-from x =
-    { over = \t2s -> x.review () >> t2s >> x.view ()
-    , review = x.view
-    , toListOf = x.review () >> List.singleton
-    , view = x.review
     }

--- a/src/Quartz/Type/Iso.elm
+++ b/src/Quartz/Type/Iso.elm
@@ -1,4 +1,4 @@
-module Quartz.Type.Iso exposing (Iso, SimpleIso, iso)
+module Quartz.Type.Iso exposing (Iso, SimpleIso, from, iso)
 
 import Quartz.Type.Optic as Optic
 
@@ -17,4 +17,13 @@ iso s2a b2t =
     , review = always b2t
     , toListOf = s2a >> List.singleton
     , view = always s2a
+    }
+
+
+from : Iso () () s t a b -> Iso () () b a t s
+from x =
+    { over = \t2s -> x.review () >> t2s >> x.view ()
+    , review = x.view
+    , toListOf = x.review () >> List.singleton
+    , view = x.review
     }

--- a/src/Quartz/Type/Optic.elm
+++ b/src/Quartz/Type/Optic.elm
@@ -1,4 +1,4 @@
-module Quartz.Type.Optic exposing (Optic, SimpleOptic)
+module Quartz.Type.Optic exposing (Optic, SimpleOptic, re)
 
 
 type alias Optic p l s t a b =
@@ -11,3 +11,21 @@ type alias Optic p l s t a b =
 
 type alias SimpleOptic p l s a =
     Optic p l s s a a
+
+
+re : Optic () () s t a b -> Optic p l b a t s
+re optic =
+    let
+        s2a : s -> a
+        s2a =
+            optic.view ()
+
+        b2t : b -> t
+        b2t =
+            optic.review ()
+    in
+    { over = \t2s -> b2t >> t2s >> s2a
+    , review = always s2a
+    , toListOf = b2t >> List.singleton
+    , view = always b2t
+    }


### PR DESCRIPTION
The `lens` library calls this `from`: https://hackage.haskell.org/package/lens-5.2.2/docs/Control-Lens-Iso.html#v:from

The `optics` library calls this `re`, and it's more general: https://hackage.haskell.org/package/optics-core-0.4.1.1/docs/Optics-Re.html#v:re