### PR TITLE
Define custom `Yes` and `No` types

### DIFF
--- a/src/Quartz.elm
+++ b/src/Quartz.elm
@@ -1,5 +1,5 @@
 module Quartz exposing
-    ( Optic, SimpleOptic, re
+    ( Optic, SimpleOptic, Yes, No, re
     , Iso, SimpleIso, iso
     , Prism, SimplePrism, prism
     , Lens, SimpleLens, lens
@@ -18,7 +18,7 @@ module Quartz exposing
 
 # Optics
 
-@docs Optic, SimpleOptic, re
+@docs Optic, SimpleOptic, Yes, No, re
 
 
 # Isos
@@ -88,9 +88,11 @@ import Quartz.Result
 import Quartz.Tuple
 import Quartz.Type.Iso
 import Quartz.Type.Lens
+import Quartz.Type.No
 import Quartz.Type.Optic
 import Quartz.Type.Prism
 import Quartz.Type.Traversal
+import Quartz.Type.Yes
 
 
 {-| This is the base optic type. All other optics are defined in terms of this
@@ -99,10 +101,10 @@ type.
 Don't be intimidated by all the type variables! Here's what they mean:
 
   - `p`: Does this optic support being used as a prism? This will either be
-    `()` for "yes" or `No`.
+    `Yes` or `No`.
 
   - `l`: Does this optic support being used as a lens? Like `p`, this will
-    either be `()` for "yes" or `No`.
+    either be `Yes` or `No`.
 
   - `s`: This is the input type. Often this is a "big" type like a record.
 
@@ -126,6 +128,18 @@ type alias SimpleOptic p l s a =
     Quartz.Type.Optic.SimpleOptic p l s a
 
 
+{-| Equivalent to `()`, the unit type.
+-}
+type alias Yes =
+    Quartz.Type.Yes.Yes
+
+
+{-| Equivalent to `Never`, the empty type.
+-}
+type alias No =
+    Quartz.Type.No.No
+
+
 {-| Use this function to flip an `Optic` around.
 
     stringToList : SimpleIso String (List Char)
@@ -137,7 +151,7 @@ type alias SimpleOptic p l s a =
         re stringToList
 
 -}
-re : Optic () () s t a b -> Optic p l b a t s
+re : Optic Yes Yes s t a b -> Optic p l b a t s
 re =
     Quartz.Type.Optic.re
 
@@ -324,7 +338,7 @@ preview =
     -- Just 1
 
 -}
-review : SimpleOptic () l s a -> a -> s
+review : SimpleOptic Yes l s a -> a -> s
 review =
     Quartz.Combinator.review
 
@@ -360,7 +374,7 @@ function that works with more types of `Optic`s.
     -- 1
 
 -}
-view : Optic p () s t a b -> s -> a
+view : Optic p Yes s t a b -> s -> a
 view =
     Quartz.Combinator.view
 

--- a/src/Quartz.elm
+++ b/src/Quartz.elm
@@ -99,10 +99,10 @@ type.
 Don't be intimidated by all the type variables! Here's what they mean:
 
   - `p`: Does this optic support being used as a prism? This will either be
-    `()` for "yes" or `Never` for "no".
+    `()` for "yes" or `No`.
 
   - `l`: Does this optic support being used as a lens? Like `p`, this will
-    either be `()` for "yes" or `Never` for "no".
+    either be `()` for "yes" or `No`.
 
   - `s`: This is the input type. Often this is a "big" type like a record.
 

--- a/src/Quartz.elm
+++ b/src/Quartz.elm
@@ -128,13 +128,15 @@ type alias SimpleOptic p l s a =
     Quartz.Type.Optic.SimpleOptic p l s a
 
 
-{-| Equivalent to `()`, the unit type.
+{-| Equivalent to `()`, the unit type. Used to signal that an `Optic` supports
+a certain feature.
 -}
 type alias Yes =
     Quartz.Type.Yes.Yes
 
 
-{-| Equivalent to `Never`, the empty type.
+{-| Equivalent to `Never`, the empty type. Like `Yes`, this is used to signal
+that an `Optic` does not support a certain feature.
 -}
 type alias No =
     Quartz.Type.No.No

--- a/src/Quartz/Combinator.elm
+++ b/src/Quartz/Combinator.elm
@@ -2,6 +2,7 @@ module Quartz.Combinator exposing (andThen, is, over, preview, review, set, toLi
 
 import Maybe.Extra
 import Quartz.Type.Optic as Optic
+import Quartz.Type.Yes as Yes
 
 
 andThen : Optic.Optic p l u v a b -> Optic.Optic p l s t u v -> Optic.Optic p l s t a b
@@ -28,9 +29,9 @@ preview optic =
     optic.toListOf >> List.head
 
 
-review : Optic.SimpleOptic () l s a -> a -> s
+review : Optic.SimpleOptic Yes.Yes l s a -> a -> s
 review optic =
-    optic.review ()
+    optic.review Yes.Yes
 
 
 set : Optic.Optic p l s t a b -> b -> s -> t
@@ -43,6 +44,6 @@ toListOf =
     .toListOf
 
 
-view : Optic.Optic p () s t a b -> s -> a
+view : Optic.Optic p Yes.Yes s t a b -> s -> a
 view optic =
-    optic.view ()
+    optic.view Yes.Yes

--- a/src/Quartz/Type/Lens.elm
+++ b/src/Quartz/Type/Lens.elm
@@ -1,10 +1,11 @@
 module Quartz.Type.Lens exposing (Lens, SimpleLens, lens)
 
+import Quartz.Type.No as No
 import Quartz.Type.Optic as Optic
 
 
 type alias Lens l s t a b =
-    Optic.Optic Never l s t a b
+    Optic.Optic No.No l s t a b
 
 
 type alias SimpleLens l s a =
@@ -14,7 +15,7 @@ type alias SimpleLens l s a =
 lens : (s -> a) -> (s -> b -> t) -> Lens l s t a b
 lens s2a sb2t =
     { over = \a2b s -> s2a s |> a2b |> sb2t s
-    , review = never >> always
+    , review = No.no >> always
     , toListOf = s2a >> List.singleton
     , view = always s2a
     }

--- a/src/Quartz/Type/No.elm
+++ b/src/Quartz/Type/No.elm
@@ -1,0 +1,15 @@
+module Quartz.Type.No exposing (No, no)
+
+
+type No
+    = No No
+
+
+no : No -> a
+no (No x) =
+    let
+        y : No
+        y =
+            x
+    in
+    no y

--- a/src/Quartz/Type/Optic.elm
+++ b/src/Quartz/Type/Optic.elm
@@ -1,5 +1,7 @@
 module Quartz.Type.Optic exposing (Optic, SimpleOptic, re)
 
+import Quartz.Type.Yes as Yes
+
 
 type alias Optic p l s t a b =
     { over : (a -> b) -> s -> t
@@ -13,16 +15,16 @@ type alias SimpleOptic p l s a =
     Optic p l s s a a
 
 
-re : Optic () () s t a b -> Optic p l b a t s
+re : Optic Yes.Yes Yes.Yes s t a b -> Optic p l b a t s
 re optic =
     let
         s2a : s -> a
         s2a =
-            optic.view ()
+            optic.view Yes.Yes
 
         b2t : b -> t
         b2t =
-            optic.review ()
+            optic.review Yes.Yes
     in
     { over = \t2s -> b2t >> t2s >> s2a
     , review = always s2a

--- a/src/Quartz/Type/Prism.elm
+++ b/src/Quartz/Type/Prism.elm
@@ -1,11 +1,12 @@
 module Quartz.Type.Prism exposing (Prism, SimplePrism, prism)
 
+import Quartz.Type.No as No
 import Quartz.Type.Optic as Optic
 import Result.Extra
 
 
 type alias Prism p s t a b =
-    Optic.Optic p Never s t a b
+    Optic.Optic p No.No s t a b
 
 
 type alias SimplePrism p s a =
@@ -17,5 +18,5 @@ prism b2t s2r =
     { over = \a2b -> s2r >> Result.Extra.unpack identity (a2b >> b2t)
     , review = always b2t
     , toListOf = s2r >> Result.Extra.unpack (always []) List.singleton
-    , view = never >> always
+    , view = No.no >> always
     }

--- a/src/Quartz/Type/Traversal.elm
+++ b/src/Quartz/Type/Traversal.elm
@@ -1,10 +1,11 @@
 module Quartz.Type.Traversal exposing (SimpleTraversal, Traversal, traversal)
 
+import Quartz.Type.No as No
 import Quartz.Type.Optic as Optic
 
 
 type alias Traversal s t a b =
-    Optic.Optic Never Never s t a b
+    Optic.Optic No.No No.No s t a b
 
 
 type alias SimpleTraversal s a =
@@ -14,7 +15,7 @@ type alias SimpleTraversal s a =
 traversal : (s -> List a) -> ((a -> b) -> s -> t) -> Traversal s t a b
 traversal s2l f =
     { over = f
-    , review = never >> always
+    , review = No.no >> always
     , toListOf = s2l
-    , view = never >> always
+    , view = No.no >> always
     }

--- a/src/Quartz/Type/Yes.elm
+++ b/src/Quartz/Type/Yes.elm
@@ -1,0 +1,5 @@
+module Quartz.Type.Yes exposing (Yes(..))
+
+
+type Yes
+    = Yes


### PR DESCRIPTION
This avoids abusing `()` and `Never` in favor of defining custom `Yes` and `No` types, respectively. 